### PR TITLE
Minor modifications to build on current OS X machine

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -1,4 +1,5 @@
-CC = gcc
+CC ?= gcc
+CARBON_HEADERS ?= "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/Developer/Headers"
 
 NAME = flisp
 SRCS = $(NAME).c builtins.c string.c equalhash.c table.c iostream.c
@@ -9,7 +10,7 @@ LIBTARGET = lib$(NAME)
 LLTDIR = llt
 LLT = $(LLTDIR)/libllt.a
 
-CONFIG = -DMACOSX -DARCH_X86_64 -DBITS64 -D__CPU__=686
+CONFIG = -DMACOSX -DARCH_X86_64 -DBITS64 -D__CPU__=686 -I$(CARBON_HEADERS)
 FLAGS = -falign-functions -Wall -Wno-strict-aliasing -I$(LLTDIR) $(CFLAGS) -DUSE_COMPUTED_GOTO $(CONFIG)
 LIBFILES = $(LLT)
 LIBS = $(LIBFILES) -lm -framework ApplicationServices

--- a/llt/dirpath.c
+++ b/llt/dirpath.c
@@ -113,8 +113,8 @@ char *get_exename(char *buf, size_t size)
     return buf;
 }
 #elif defined(MACOSX)
-#include "/Developer/Headers/FlatCarbon/Processes.h"
-#include "/Developer/Headers/FlatCarbon/Files.h"
+#include <FlatCarbon/Processes.h>
+#include <FlatCarbon/Files.h>
 char *get_exename(char *buf, size_t size)
 {
     ProcessSerialNumber PSN;

--- a/llt/dtypes.h
+++ b/llt/dtypes.h
@@ -28,6 +28,7 @@
 #endif
 
 
+#if !defined (BITS32) && !defined (BITS64)
 #ifndef __SIZEOF_POINTER__
 #  error "__SIZEOF_POINTER__ undefined"
 #endif
@@ -37,6 +38,7 @@
 #  define BITS32
 #else
 #  error "this is one weird machine"
+#endif
 #endif
 
 


### PR DESCRIPTION
I updated the path to the Carbon headers, which has changed with recent XCode versions. It is configurable by the CARBON_HEADERS environment variable. I also wrapped the BITS32/64 define in a check to see whether one is already defined, since BIT64 is set in Makefile.macosx. The check around __SIZEOF_POINTER__ was failing even when it was defined... not sure why. It happened GCC 4.2.1, GCC 4.7.2 and Clang 4.2 (LLVM 3.2).
