### PR TITLE
Make FreeBSD a "first class citizen" among femtolisp's build OSes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CC = gcc
+FREEBSD-GE-10 = $(shell test `uname` = FreeBSD -a `uname -r | cut -d. -f1` -ge 10 && echo YES)
+CC = $(if $(FREEBSD-GE-10),clang,gcc)
 
 NAME = flisp
 SRCS = $(NAME).c builtins.c string.c equalhash.c table.c iostream.c
@@ -32,7 +33,7 @@ flmain.o: flmain.c flisp.h
 flmain.do: flmain.c flisp.h
 
 $(LLT):
-	cd $(LLTDIR) && make
+	cd $(LLTDIR) && $(MAKE)
 
 $(LIBTARGET).da: $(DOBJS)
 	rm -rf $@
@@ -44,7 +45,7 @@ $(LIBTARGET).a: $(OBJS)
 
 debug: $(DOBJS) $(LIBFILES) $(LIBTARGET).da flmain.do
 	$(CC) $(DEBUGFLAGS) $(DOBJS) flmain.do -o $(EXENAME) $(LIBS) $(LIBTARGET).da
-	make test
+	$(MAKE) test
 
 release: $(OBJS) $(LIBFILES) $(LIBTARGET).a flmain.o
 	$(CC) $(SHIPFLAGS) $(OBJS) flmain.o -o $(EXENAME) $(LIBS) $(LIBTARGET).a

--- a/flisp.c
+++ b/flisp.c
@@ -2307,6 +2307,8 @@ static void lisp_init(size_t initial_heapsize)
     set(symbol("*os-name*"), symbol("macos"));
 #elif defined(OPENBSD)
     set(symbol("*os-name*"), symbol("openbsd"));
+#elif defined(FREEBSD)
+    set(symbol("*os-name*"), symbol("freebsd"));
 #else
     set(symbol("*os-name*"), symbol("unknown"));
 #endif

--- a/llt/Makefile
+++ b/llt/Makefile
@@ -1,4 +1,5 @@
-CC = gcc
+FREEBSD-GE-10 = $(shell test `uname` = FreeBSD -a `uname -r | cut -d. -f1` -ge 10 && echo YES)
+CC = $(if $(FREEBSD-GE-10),clang,gcc)
 
 SRCS = bitvector.c hashing.c socket.c timefuncs.c ptrhash.c utf8.c ios.c \
 	dirpath.c htable.c bitvector-ops.c int2str.c dump.c random.c \

--- a/llt/dirpath.c
+++ b/llt/dirpath.c
@@ -95,7 +95,7 @@ char *get_exename(char *buf, size_t size)
   /* OpenBSD currently has no way of determining a processes pathname */
   return NULL;
 }
-#elif defined(__FreeBSD__)
+#elif defined(FREEBSD)
 #include <sys/types.h>
 #include <sys/sysctl.h>
 

--- a/llt/dtypes.h
+++ b/llt/dtypes.h
@@ -23,13 +23,15 @@
 #  define MACOSX
 #elif defined(__OpenBSD__)
 #  define OPENBSD
+#elif defined(__FreeBSD__)
+#  define FREEBSD
 #elif defined(_WIN32)
 #  define WIN32
 #else
 #  error "unknown platform"
 #endif
 
-#if defined(OPENBSD)
+#if defined(OPENBSD) || defined(FREEBSD)
 #if defined(__x86_64__)
 #  define __SIZEOF_POINTER__ 8
 #else
@@ -70,7 +72,7 @@
 #  define BIG_ENDIAN     __BIG_ENDIAN
 #  define PDP_ENDIAN     __PDP_ENDIAN
 #  define BYTE_ORDER     __BYTE_ORDER
-#elif defined(MACOSX) || defined(OPENBSD)
+#elif defined(MACOSX) || defined(OPENBSD) || defined(FREEBSD)
 #  include <machine/endian.h>
 #  define __LITTLE_ENDIAN  LITTLE_ENDIAN
 #  define __BIG_ENDIAN     BIG_ENDIAN

--- a/llt/timefuncs.c
+++ b/llt/timefuncs.c
@@ -106,7 +106,7 @@ void timestring(double seconds, char *buffer, size_t len)
 #endif
 }
 
-#if defined(LINUX) || defined(MACOSX) || defined(OPENBSD)
+#if defined(LINUX) || defined(MACOSX) || defined(OPENBSD) || defined(FREEBSD)
 extern char *strptime(const char *s, const char *format, struct tm *tm);
 double parsetime(const char *str)
 {

--- a/tiny/Makefile
+++ b/tiny/Makefile
@@ -1,4 +1,5 @@
-CC = gcc
+FREEBSD-GE-10 = $(shell test `uname` = FreeBSD -a `uname -r | cut -d. -f1` -ge 10 && echo YES)
+CC = $(if $(FREEBSD-GE-10),clang,gcc)
 
 NAME = lisp
 SRC = $(NAME).c


### PR DESCRIPTION
It looks like FreeBSD should do what OpenBSD does in femtolisp's code.  The biggest change here (I think) is that of determining the correct value of CC in the Makefile(s).  As of version 10, FreeBSD's base compiler is clang; so there is now some logic in the Makefile(s) to determine if the build is occurring on a FreeBSD system >= 10.0.  If so, then the value of CC will be "clang"; otherwise, it will be "gcc", as before.

The new changes build and test successfully on my FreeBSD 10.1 system.

N.B. I have **not yet** tested this change for systems other than FreeBSD 10.1, e.g. any Linux or even FreeBSD < 10.  I believe that, if you want the extra Makefile logic, it warrants testing on other systems.  I'd be happy to do this, but I won't be able to until Monday (2 days from now) though.