### PR TITLE
Make GitHub detect lisp files as Scheme.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.lsp linguist-language=Scheme
+flisp.boot linguist-language=Scheme


### PR DESCRIPTION
Hello,

GitHub currently thinks some of the `.lsp` files are Common Lisp or NewLisp.  This adds a `.gitattributes` file to change that to Scheme.  This is also done for the `flisp.boot` file.
