### PR TITLE
Fix parsetime to initialize timezone, issue #34.

### DIFF
--- a/llt/timefuncs.c
+++ b/llt/timefuncs.c
@@ -82,7 +82,7 @@ void timestring(double seconds, char *buffer, size_t len)
 {
     time_t tme = (time_t)seconds;
 
-#ifdef LINUX
+#if defined(LINUX) || defined(MACOSX) || defined(OPENBSD) || defined(FREEBSD)
     char *fmt = "%c"; /* needed to suppress GCC warning */
     struct tm tm;
 
@@ -117,6 +117,8 @@ double parsetime(const char *str)
 
     res = strptime(str, fmt, &tm);
     if (res != NULL) {
+        tm.tm_isdst = -1; /* Not set by strptime(); tells mktime() to determine
+                            whether daylight saving time is in effect */
         t = mktime(&tm);
         if (t == ((time_t)-1))
             return -1;

--- a/tests/unittest.lsp
+++ b/tests/unittest.lsp
@@ -283,5 +283,9 @@
 (assert (not (equal? (hash (iota 41))
 		     (hash (iota 42)))))
 
+(if (top-level-bound? 'time.fromstring)
+    (assert (let ((ts (time.string (time.now))))
+                (eqv? ts (time.string (time.fromstring ts))))))
+
 (princ "all tests pass\n")
 #t


### PR DESCRIPTION
Here's a fix and unit test for parsetime; also made timestring consistent with parsetime by including MACOSX OPENBSD and FREEBSD in the LINUX conditional test to use strftime.