### PR TITLE
Correct the warning from incompatible types in number format string.

### DIFF
--- a/tiny/lisp.c
+++ b/tiny/lisp.c
@@ -501,7 +501,7 @@ void print(FILE *f, value_t v)
     value_t cd;
 
     switch (tag(v)) {
-    case TAG_NUM: fprintf(f, "%ld", numval(v)); break;
+    case TAG_NUM: fprintf(f, "%lld", numval(v)); break;
     case TAG_SYM: fprintf(f, "%s", ((symbol_t*)ptr(v))->name); break;
     case TAG_BUILTIN: fprintf(f, "#<builtin %s>",
                               builtin_names[intval(v)]); break;


### PR DESCRIPTION
```
$ make
gcc -O3 -fomit-frame-pointer -Wall -Wextra lisp.c -o lisp
lisp.c:504:37: warning: format specifies type 'long' but the argument has type 'number_t' (aka 'long long') [-Wformat]
    case TAG_NUM: fprintf(f, "%ld", numval(v)); break;
                              ~~~   ^~~~~~~~~
                              %lld
lisp.c:59:20: note: expanded from macro 'numval'
                   ^~~~~~~~~~~~~~~~~~~~
1 warning generated.
```