### PR TITLE
Fix warnings

### DIFF
--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -10,7 +10,7 @@ LIBTARGET = lib$(NAME)
 LLTDIR = llt
 LLT = $(LLTDIR)/libllt.a
 
-CONFIG = -DMACOSX -DARCH_X86_64 -DBITS64 -D__CPU__=686 -I$(CARBON_HEADERS)
+CONFIG = -DBITS64 -D__CPU__=686 -I$(CARBON_HEADERS)
 FLAGS = -falign-functions -Wall -Wno-strict-aliasing -I$(LLTDIR) $(CFLAGS) -DUSE_COMPUTED_GOTO $(CONFIG)
 LIBFILES = $(LLT)
 LIBS = $(LIBFILES) -lm -framework ApplicationServices

--- a/flisp.c
+++ b/flisp.c
@@ -1791,7 +1791,7 @@ static value_t apply_cl(uint32_t nargs)
             i = GET_INT32(ip); ip+=4;
             n = GET_INT32(ip); ip+=4;
             s = GET_INT32(ip); ip+=4;
-            nargs = process_keys(v, i, n, abs(s)-(i+n), bp, nargs, s<0);
+            nargs = process_keys(v, i, n, labs(s)-(i+n), bp, nargs, s<0);
             NEXT_OP;
 
 #ifndef USE_COMPUTED_GOTO

--- a/llt/Makefile.macosx
+++ b/llt/Makefile.macosx
@@ -9,7 +9,7 @@ TARGET = libllt.a
 
 # OS flags: LINUX, WIN32, MACOSX
 # architecture flags: __CPU__=xxx, BITS64, ARCH_X86, ARCH_X86_64
-CONFIG = -DMACOSX -DARCH_X86_64 -DBITS64 -D__CPU__=686
+CONFIG = -DBITS64 -D__CPU__=686
 FLAGS = -Wall -Wno-strict-aliasing $(CFLAGS) $(CONFIG)
 LIBS =
 


### PR DESCRIPTION
abs(i) takes an int, thus labs(l) should be used
macOS (clang and gcc) already defines MACOSX and ARCH_X86_64.
