### PR TITLE
Fix "use-after-relocate" in stream_to_string

### DIFF
--- a/iostream.c
+++ b/iostream.c
@@ -389,7 +389,7 @@ value_t stream_to_string(value_t *ps)
         n = st->size;
         str = cvalue_string(n);
         memcpy(cvalue_data(str), value2c(ios_t*,*ps)->buf, n);
-        ios_trunc(st, 0);
+        ios_trunc(value2c(ios_t*,*ps), 0);
     }
     else {
         char *b = ios_takebuf(st, &n); n--;


### PR DESCRIPTION
cvalue_string() can cause a gc - this potentially makes the ios_t-pointer that is cached in the local variable "st" invalid.