### PR TITLE
#define _XOPEN_SOURCE instead of prototyping wcwidth

### DIFF
--- a/llt/utf8.c
+++ b/llt/utf8.c
@@ -12,6 +12,7 @@
   valid.
   A UTF-8 validation routine is included.
 */
+#define _XOPEN_SOURCE 700
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/llt/utf8.h
+++ b/llt/utf8.h
@@ -16,7 +16,7 @@ typedef unsigned long long u_int64_t;
 
 extern int locale_is_utf8;
 
-#if defined(__WIN32__) || defined(__linux__)
+#if defined(__WIN32__)
 extern int wcwidth(uint32_t);
 #endif
 


### PR DESCRIPTION
wcwidth doesn't need to be prototyped on glibc if _XOPEN_SOURCE is defined (which is used to expose symbols in headers from the Single UNIX Specification on glibc based and possibly other *nix systems). This also avoids a conflict when compiling with musl, as wcwidth is exposed there regardless of whether _XOPEN_SOURCE is defined or not.