### PR TITLE
Update all tiny interpreters for 64-bit builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /llt/*.o
 /llt/*.a
 /flisp.boot.bak
+/tiny/lisp
+/tiny/lisp-nontail
+/tiny/lisp2
+/tiny/lispf

--- a/tiny/lisp-nontail.c
+++ b/tiny/lisp-nontail.c
@@ -26,8 +26,13 @@
 #include <ctype.h>
 #include <sys/types.h>
 
+#ifdef __LP64__
+typedef u_int64_t value_t;
+typedef int64_t number_t;
+#else
 typedef u_int32_t value_t;
 typedef int32_t number_t;
+#endif
 
 typedef struct {
     value_t car;

--- a/tiny/lisp-nontail.c
+++ b/tiny/lisp-nontail.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 
 #include <ctype.h>
+#include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -28,9 +29,11 @@
 #include <string.h>
 
 #ifdef __LP64__
+#define NUM_FORMAT "%" PRId64
 typedef u_int64_t value_t;
 typedef int64_t number_t;
 #else
+#define NUM_FORMAT "%" PRId32
 typedef u_int32_t value_t;
 typedef int32_t number_t;
 #endif
@@ -504,7 +507,7 @@ void print(FILE *f, value_t v)
     value_t cd;
 
     switch (tag(v)) {
-    case TAG_NUM: fprintf(f, "%d", numval(v)); break;
+    case TAG_NUM: fprintf(f, NUM_FORMAT, numval(v)); break;
     case TAG_SYM: fprintf(f, "%s", ((symbol_t*)ptr(v))->name); break;
     case TAG_BUILTIN: fprintf(f, "#<builtin %s>",
                               builtin_names[intval(v)]); break;

--- a/tiny/lisp-nontail.c
+++ b/tiny/lisp-nontail.c
@@ -18,23 +18,22 @@
   Public Domain
 */
 
-#include <sys/types.h>
-
 #include <ctype.h>
 #include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifdef __LP64__
 #define NUM_FORMAT "%" PRId64
-typedef u_int64_t value_t;
+typedef uint64_t value_t;
 typedef int64_t number_t;
 #else
 #define NUM_FORMAT "%" PRId32
-typedef u_int32_t value_t;
+typedef uint32_t value_t;
 typedef int32_t number_t;
 #endif
 
@@ -96,7 +95,7 @@ static char *stack_bottom;
 #define PROCESS_STACK_SIZE (2*1024*1024)
 #define N_STACK 49152
 static value_t Stack[N_STACK];
-static u_int32_t SP = 0;
+static uint32_t SP = 0;
 #define PUSH(v) (Stack[SP++] = (v))
 #define POP()   (Stack[--SP])
 #define POPN(n) (SP-=(n))
@@ -188,7 +187,7 @@ static unsigned char *fromspace;
 static unsigned char *tospace;
 static unsigned char *curheap;
 static unsigned char *lim;
-static u_int32_t heapsize = 64*1024;//bytes
+static uint32_t heapsize = 64*1024;//bytes
 
 void lisp_init(void)
 {
@@ -271,7 +270,7 @@ void gc(void)
 {
     static int grew = 0;
     unsigned char *temp;
-    u_int32_t i;
+    uint32_t i;
 
     curheap = tospace;
     lim = curheap+heapsize-sizeof(cons_t);
@@ -314,7 +313,7 @@ static int symchar(char c)
     return (!isspace(c) && !strchr(special, c));
 }
 
-static u_int32_t toktype = TOK_NONE;
+static uint32_t toktype = TOK_NONE;
 static value_t tokval;
 static char buf[256];
 
@@ -385,7 +384,7 @@ static int read_token(FILE *f, char c)
     return i;
 }
 
-static u_int32_t peek(FILE *f)
+static uint32_t peek(FILE *f)
 {
     char c, *end;
     number_t x;
@@ -436,7 +435,7 @@ static u_int32_t peek(FILE *f)
 static void read_list(FILE *f, value_t *pval)
 {
     value_t c, *pc;
-    u_int32_t t;
+    uint32_t t;
 
     PUSH(NIL);
     pc = &Stack[SP-1];  // to keep track of current cons cell
@@ -547,7 +546,7 @@ value_t eval_sexpr(value_t e, value_t *penv)
     value_t *rest;
     cons_t *c;
     symbol_t *sym;
-    u_int32_t saveSP;
+    uint32_t saveSP;
     int i, nargs, noeval=0;
     number_t s, n;
 

--- a/tiny/lisp-nontail.c
+++ b/tiny/lisp-nontail.c
@@ -18,13 +18,14 @@
   Public Domain
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <sys/types.h>
+
+#include <ctype.h>
 #include <setjmp.h>
 #include <stdarg.h>
-#include <ctype.h>
-#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __LP64__
 typedef u_int64_t value_t;

--- a/tiny/lisp.c
+++ b/tiny/lisp.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 
 #include <ctype.h>
+#include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -28,9 +29,11 @@
 #include <string.h>
 
 #ifdef __LP64__
+#define NUM_FORMAT "%" PRId64
 typedef u_int64_t value_t;
 typedef int64_t number_t;
 #else
+#define NUM_FORMAT "%" PRId32
 typedef u_int32_t value_t;
 typedef int32_t number_t;
 #endif
@@ -502,7 +505,7 @@ void print(FILE *f, value_t v)
     value_t cd;
 
     switch (tag(v)) {
-    case TAG_NUM: fprintf(f, "%ld", numval(v)); break;
+    case TAG_NUM: fprintf(f, NUM_FORMAT, numval(v)); break;
     case TAG_SYM: fprintf(f, "%s", ((symbol_t*)ptr(v))->name); break;
     case TAG_BUILTIN: fprintf(f, "#<builtin %s>",
                               builtin_names[intval(v)]); break;

--- a/tiny/lisp.c
+++ b/tiny/lisp.c
@@ -18,23 +18,22 @@
   Public Domain
 */
 
-#include <sys/types.h>
-
 #include <ctype.h>
 #include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifdef __LP64__
 #define NUM_FORMAT "%" PRId64
-typedef u_int64_t value_t;
+typedef uint64_t value_t;
 typedef int64_t number_t;
 #else
 #define NUM_FORMAT "%" PRId32
-typedef u_int32_t value_t;
+typedef uint32_t value_t;
 typedef int32_t number_t;
 #endif
 
@@ -96,7 +95,7 @@ static char *stack_bottom;
 #define PROCESS_STACK_SIZE (2*1024*1024)
 #define N_STACK 49152
 static value_t Stack[N_STACK];
-static u_int32_t SP = 0;
+static uint32_t SP = 0;
 #define PUSH(v) (Stack[SP++] = (v))
 #define POP()   (Stack[--SP])
 #define POPN(n) (SP-=(n))
@@ -188,7 +187,7 @@ static unsigned char *fromspace;
 static unsigned char *tospace;
 static unsigned char *curheap;
 static unsigned char *lim;
-static u_int32_t heapsize = 64*1024;//bytes
+static uint32_t heapsize = 64*1024;//bytes
 
 void lisp_init(void)
 {
@@ -271,7 +270,7 @@ void gc(void)
 {
     static int grew = 0;
     unsigned char *temp;
-    u_int32_t i;
+    uint32_t i;
 
     curheap = tospace;
     lim = curheap+heapsize-sizeof(cons_t);
@@ -314,7 +313,7 @@ static int symchar(char c)
     return (!isspace(c) && !strchr(special, c));
 }
 
-static u_int32_t toktype = TOK_NONE;
+static uint32_t toktype = TOK_NONE;
 static value_t tokval;
 static char buf[256];
 
@@ -386,7 +385,7 @@ static int read_token(FILE *f, char c)
     return (dot && (totread==2));
 }
 
-static u_int32_t peek(FILE *f)
+static uint32_t peek(FILE *f)
 {
     char c, *end;
     number_t x;
@@ -434,7 +433,7 @@ static u_int32_t peek(FILE *f)
 static void read_list(FILE *f, value_t *pval)
 {
     value_t c, *pc;
-    u_int32_t t;
+    uint32_t t;
 
     PUSH(NIL);
     pc = &Stack[SP-1];  // to keep track of current cons cell
@@ -548,7 +547,7 @@ value_t eval_sexpr(value_t e, value_t *penv)
     value_t *rest;
     cons_t *c;
     symbol_t *sym;
-    u_int32_t saveSP;
+    uint32_t saveSP;
     int i, nargs, noeval=0;
     number_t s, n;
 
@@ -983,7 +982,7 @@ static char *infile = NULL;
 value_t toplevel_eval(value_t expr)
 {
     value_t v;
-    u_int32_t saveSP = SP;
+    uint32_t saveSP = SP;
     PUSH(NIL);
     v = eval(expr, &Stack[SP-1]);
     SP = saveSP;

--- a/tiny/lisp.c
+++ b/tiny/lisp.c
@@ -18,13 +18,14 @@
   Public Domain
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <sys/types.h>
+
+#include <ctype.h>
 #include <setjmp.h>
 #include <stdarg.h>
-#include <ctype.h>
-#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __LP64__
 typedef u_int64_t value_t;

--- a/tiny/lisp2.c
+++ b/tiny/lisp2.c
@@ -42,6 +42,7 @@
 #include <sys/types.h>
 
 #include <ctype.h>
+#include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -49,9 +50,11 @@
 #include <string.h>
 
 #ifdef __LP64__
+#define NUM_FORMAT "%" PRId64
 typedef u_int64_t value_t;
 typedef int64_t number_t;
 #else
+#define NUM_FORMAT "%" PRId32
 typedef u_int32_t value_t;
 typedef int32_t number_t;
 #endif
@@ -765,7 +768,7 @@ static void do_print(FILE *f, value_t v, int princ)
     char *name;
 
     switch (tag(v)) {
-    case TAG_NUM: fprintf(f, "%d", numval(v)); break;
+    case TAG_NUM: fprintf(f, NUM_FORMAT, numval(v)); break;
     case TAG_SYM:
         name = ((symbol_t*)ptr(v))->name;
         if (princ)

--- a/tiny/lisp2.c
+++ b/tiny/lisp2.c
@@ -39,13 +39,14 @@
   Public Domain
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <sys/types.h>
+
+#include <ctype.h>
 #include <setjmp.h>
 #include <stdarg.h>
-#include <ctype.h>
-#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __LP64__
 typedef u_int64_t value_t;

--- a/tiny/lisp2.c
+++ b/tiny/lisp2.c
@@ -47,8 +47,13 @@
 #include <ctype.h>
 #include <sys/types.h>
 
+#ifdef __LP64__
+typedef u_int64_t value_t;
+typedef int64_t number_t;
+#else
 typedef u_int32_t value_t;
 typedef int32_t number_t;
+#endif
 
 typedef struct {
     value_t car;

--- a/tiny/lispf.c
+++ b/tiny/lispf.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 
 #include <ctype.h>
+#include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -40,11 +41,14 @@ typedef u_int32_t value_t;
 #endif
 
 #ifdef FLOAT
+#define NUM_FORMAT "%f"
 typedef float number_t;
 #else
 #ifdef __LP64__
+#define NUM_FORMAT "%" PRId64
 typedef int64_t number_t;
 #else
+#define NUM_FORMAT "%" PRId32
 typedef int32_t number_t;
 #endif
 #endif
@@ -73,13 +77,11 @@ typedef struct _symbol_t {
 #ifdef FLOAT
 #define number(x) ((*(value_t*)&(x))&~0x3)
 #define numval(x)  (*(number_t*)&(x))
-#define NUM_FORMAT "%f"
 extern float strtof(const char *nptr, char **endptr);
 #define strtonum(s, e) strtof(s, e)
 #else
 #define number(x) ((value_t)((x)<<2))
 #define numval(x)  (((number_t)(x))>>2)
-#define NUM_FORMAT "%d"
 #define strtonum(s, e) strtol(s, e, 10)
 #endif
 #define intval(x)  (((int)(x))>>2)

--- a/tiny/lispf.c
+++ b/tiny/lispf.c
@@ -24,13 +24,14 @@
   Public Domain
 */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <sys/types.h>
+
+#include <ctype.h>
 #include <setjmp.h>
 #include <stdarg.h>
-#include <ctype.h>
-#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __LP64__
 typedef u_int64_t value_t;

--- a/tiny/lispf.c
+++ b/tiny/lispf.c
@@ -24,20 +24,19 @@
   Public Domain
 */
 
-#include <sys/types.h>
-
 #include <ctype.h>
 #include <inttypes.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifdef __LP64__
-typedef u_int64_t value_t;
+typedef uint64_t value_t;
 #else
-typedef u_int32_t value_t;
+typedef uint32_t value_t;
 #endif
 
 #ifdef FLOAT
@@ -119,7 +118,7 @@ static char *stack_bottom;
 #define PROCESS_STACK_SIZE (2*1024*1024)
 #define N_STACK 49152
 static value_t Stack[N_STACK];
-static u_int32_t SP = 0;
+static uint32_t SP = 0;
 #define PUSH(v) (Stack[SP++] = (v))
 #define POP()   (Stack[--SP])
 #define POPN(n) (SP-=(n))
@@ -211,7 +210,7 @@ static unsigned char *fromspace;
 static unsigned char *tospace;
 static unsigned char *curheap;
 static unsigned char *lim;
-static u_int32_t heapsize = 64*1024;//bytes
+static uint32_t heapsize = 64*1024;//bytes
 
 void lisp_init(void)
 {
@@ -294,7 +293,7 @@ void gc(void)
 {
     static int grew = 0;
     unsigned char *temp;
-    u_int32_t i;
+    uint32_t i;
 
     curheap = tospace;
     lim = curheap+heapsize-sizeof(cons_t);
@@ -337,7 +336,7 @@ static int symchar(char c)
     return (!isspace(c) && !strchr(special, c));
 }
 
-static u_int32_t toktype = TOK_NONE;
+static uint32_t toktype = TOK_NONE;
 static value_t tokval;
 static char buf[256];
 
@@ -408,7 +407,7 @@ static int read_token(FILE *f, char c)
     return i;
 }
 
-static u_int32_t peek(FILE *f)
+static uint32_t peek(FILE *f)
 {
     char c, *end;
     number_t x;
@@ -459,7 +458,7 @@ static u_int32_t peek(FILE *f)
 static void read_list(FILE *f, value_t *pval)
 {
     value_t c, *pc;
-    u_int32_t t;
+    uint32_t t;
 
     PUSH(NIL);
     pc = &Stack[SP-1];  // to keep track of current cons cell
@@ -573,7 +572,7 @@ value_t eval_sexpr(value_t e, value_t *penv)
     value_t *rest;
     cons_t *c;
     symbol_t *sym;
-    u_int32_t saveSP;
+    uint32_t saveSP;
     int i, nargs, noeval=0;
     number_t s, n;
 

--- a/tiny/lispf.c
+++ b/tiny/lispf.c
@@ -32,11 +32,20 @@
 #include <ctype.h>
 #include <sys/types.h>
 
+#ifdef __LP64__
+typedef u_int64_t value_t;
+#else
 typedef u_int32_t value_t;
+#endif
+
 #ifdef FLOAT
 typedef float number_t;
 #else
+#ifdef __LP64__
+typedef int64_t number_t;
+#else
 typedef int32_t number_t;
+#endif
 #endif
 
 typedef struct {


### PR DESCRIPTION
These now compile without producing any warnings on a 64-bit system:

```
clang -Wall -Wextra -pedantic -std=c99 -o lisp lisp.c
clang -Wall -Wextra -pedantic -std=c99 -o lisp-nontail lisp-nontail.c
clang -Wall -Wextra -pedantic -std=c99 -o lisp2 lisp2.c
clang -Wall -Wextra -pedantic -std=c99 -o lispf lispf.c
clang -Wall -Wextra -pedantic -std=c99 -o lispf lispf.c -D FLOAT
```